### PR TITLE
Update _env.php

### DIFF
--- a/config/_env.php
+++ b/config/_env.php
@@ -2,5 +2,5 @@
 // set the mode here only if it is not already set.
 // this allows for setting via web server, integration testing, etc.
 if (! isset($_ENV['AURA_CONFIG_MODE'])) {
-    $_ENV['AURA_CONFIG_MODE'] = 'dev';
+    $_ENV['AURA_CONFIG_MODE'] = getenv('AURA_CONFIG_MODE') ?: 'dev';
 }


### PR DESCRIPTION
If variable is not set, sometimes it's not accessible through $_ENV but through getenv yes. If not present in getenv it will return false.